### PR TITLE
Air puffs

### DIFF
--- a/scripts/make_demo_puffs_schemas.py
+++ b/scripts/make_demo_puffs_schemas.py
@@ -1,0 +1,8 @@
+import os
+import datajoint as dj
+
+dj.config['database.host'] = 'datajoint00.pni.princeton.edu'
+dj.config['database.user'] = os.environ.get('DJ_DB_USER')
+dj.config['database.password'] = os.environ.get('DJ_DB_PASS')
+dj.config['database.prefix'] = 'u19_'
+from u19_pipeline import puffs_lab, puffs_acquisition, puffs_behavior

--- a/u19_pipeline/acquisition.py
+++ b/u19_pipeline/acquisition.py
@@ -29,7 +29,8 @@ class Session(dj.Manual):
     session_start_time   : datetime                     # start time
     session_end_time=null : datetime                     # end time
     -> lab.Location.proj(session_location="location")
-    -> task.TaskLevelParameterSet
+    -> task.TaskLevelParameterSet.proj(last_level="level")
+    -> [nullable] lab.ManipulationType.proj(manipulation_type="manipulation_type") # The type of manipulation
     stimulus_bank=""     : varchar(255)                 # path to the function to generate the stimulus
     stimulus_commit=""   : varchar(64)                  # git hash for the version of the function
     session_performance  : float                        # percentage correct on this session

--- a/u19_pipeline/behavior.py
+++ b/u19_pipeline/behavior.py
@@ -81,7 +81,6 @@ class TowersBlock(dj.Imported):
         vi_start             : int
         """
 
-
 @schema
 class TowersBlockTrialVideo(dj.Imported):
     definition = """
@@ -116,4 +115,35 @@ class TowersSessionPsych(dj.Computed):
     session_pright_error=null : blob                         # confidence interval for precentage went right of data
     session_delta_fit=null : blob                         # num of right - num of left, x ticks for fitting results
     session_pright_fit=null : blob                         # fitting results for percent went right
+    """
+
+@schema
+class PuffsSession(dj.Imported):
+    definition = """
+    -> acquisition.Session
+    ---
+    rig                  : tinyint                      # an integer that describes which rig was used. 0 corresponds to location = "pni-ltl016-05", 1 corresponds to location = "wang-behavior"
+    """
+
+@schema
+class PuffsTrial(dj.Part):
+    definition = """
+    -> PuffsSession
+    trial_idx            : int                          # trial index, keep the original number in the hdf5 file
+    ---
+    -> task.TaskLevelParameterSet.proj(level="level")   # The difficulty level of the trial
+    trial_type           : enum('L','R')                # answer of this trial, left or right
+    choice               : enum('L','R','nil')          # choice of this trial, left or right
+    trial_prior_p_left   : float                        # prior probablity of this trial for left
+    trial_rel_start      : float                        # start time of the trial relative to the beginning of the session [seconds]
+    trial_rel_finish     : float                        # end time of the trial relative to the beginning of the session [seconds]
+    trial_duration       : float                        # duration of the trial [seconds]
+    cue_period           : float                        # duration of cue period [seconds]
+    num_puffs_received_L : tinyint                      # number of puffs actually received on the left side
+    num_puffs_intended_L : tinyint                      # number of puffs intended on the left side
+    num_puffs_received_R : tinyint                      # number of puffs actually received on the right side
+    num_puffs_intended_R : tinyint                      # number of puffs intended on the right side
+    reward_rel_start     : float                        # timing of reward relative to the beginning of the session [seconds]
+    reward_scale         : float                        # subject is given 4 microliters * reward_scale as a reward 
+    rule                 : tinyint                      # 
     """

--- a/u19_pipeline/lab.py
+++ b/u19_pipeline/lab.py
@@ -268,3 +268,14 @@ class EndpointNotification(dj.Lookup):
     email                 : varchar(64)                  # email address
     ---
     """
+
+@schema
+class ManipulationType(dj.Lookup):
+    definition = """
+    manipulation_type           : varchar(64)   
+    ---
+    manipulation_description    : varchar(2555)
+    """
+    contents = [
+        ['optogenetics', 'optogentic manipulation'],
+   ]

--- a/u19_pipeline/puffs_acquisition.py
+++ b/u19_pipeline/puffs_acquisition.py
@@ -1,0 +1,17 @@
+"""This module defines tables in the schema ahoag_puffs_acquisition_demo"""
+
+import datajoint as dj
+from . import puffs_lab
+
+schema = dj.schema(dj.config['database.prefix'] + 'puffs_acquisition')
+
+
+@schema
+class PuffsFileAcquisition(dj.Manual):
+    definition = """
+    -> puffs_lab.PuffsCohort
+    rig                  : tinyint                      # an integer that describes which rig was used. 0 corresponds to location = "pni-ltl016-05", 1 corresponds to location = "wang-behavior"
+    h5_filename          : varchar(256)                 # The full path name, e.g. "data.h5" or "data_compressed_XX.h5" for the h5 behavior data file
+    ---
+    ingested             : boolean                      # A flag for whether this file has already been ingested.  
+    """

--- a/u19_pipeline/puffs_behavior.py
+++ b/u19_pipeline/puffs_behavior.py
@@ -1,0 +1,60 @@
+"""This module defines tables in the schema ahoag_puffs_behavior_demo"""
+
+import datajoint as dj
+from . import acquisition, task
+
+schema = dj.schema(dj.config['database.prefix'] + 'puffs_behavior')
+
+@schema
+class PuffsSession(dj.Manual):
+    definition = """
+    -> acquisition.Session
+    ---
+    session_params = NULL       : blob                         # The parameters for this session, e.g. phase_durations, whether puffs are on, etc... 
+    rig                         : tinyint                      # an integer that describes which rig was used. 0 corresponds to location = "pni-ltl016-05", 1 corresponds to location = "wang-behavior"
+    notes = ''                  : varchar(1024)                # notes recorded by experimenter during the session
+    stdout = NULL               : blob                         # stdout for the GUI during the session
+    stderr = NULL               : blob                         # stderr for the GUI during the session
+    sync = NULL                 : blob                         # At the start of the session, the software runs multiple python processes. This column contains the times of these processes in seconds 
+    """
+
+    class Trial(dj.Part):
+    	definition = """
+        -> PuffsSession
+        trial_idx            : int                          # trial index, keep the original number in the file
+        ---
+		-> task.TaskLevelParameterSet.proj(level="level")   # The difficulty level of the trial
+        trial_type           : enum('L','R')                # answer of this trial, left or right
+        choice               : enum('L','R','nil')          # choice of this trial, left or right
+        trial_prior_p_left   : float                        # prior probablity of this trial for left
+	    trial_rel_start      : float                        # start time of the trial relative to the beginning of the session [seconds]
+	    trial_rel_finish     : float                        # end time of the trial relative to the beginning of the session [seconds]
+	    trial_duration       : float                        # duration of the trial [seconds]
+	    cue_period           : float                        # duration of cue period [seconds]
+        num_puffs_intended_l : tinyint                      # number of puffs intended on the left side
+	    num_puffs_received_r : tinyint                      # number of puffs actually received on the right side
+	    num_puffs_intended_r : tinyint                      # number of puffs intended on the right side
+	    num_puffs_received_l : tinyint                      # number of puffs actually received on the left side
+	    reward_rel_start     : float                        # timing of reward relative to the beginning of the session [seconds]
+	    reward_scale         : float                        # subject is given 4 microliters * reward_scale as a reward 
+	    rule                 : tinyint                      # 
+        """
+    
+    class TrialPhase(dj.Part):
+    	definition = """
+        -> master.Trial
+        phase                : tinyint                      # phase index, 0=intro, 1=stimulus period, ... see Puffs Task Documentation
+        ---
+	    phase_rel_start      : float                        # start time of the phase relative to the beginning of the session [seconds]
+	    phase_rel_finish     : float                        # end time of the phase relative to the beginning of the session [seconds]
+        """
+    
+    class Puff(dj.Part):
+    	definition = """
+        -> master.Trial
+        puff_idx             : tinyint                     # the index of the puff in this particular trial
+        side                 : tinyint                     # 0 = left side, 1 = right side
+        ---
+	    puff_rel_time        : float                       # time of the puff relative to the beginning of the trial [seconds]
+        """
+

--- a/u19_pipeline/puffs_lab.py
+++ b/u19_pipeline/puffs_lab.py
@@ -1,0 +1,16 @@
+"""This module defines tables in the schema ahoag_puffs_lab_demo"""
+
+import datajoint as dj
+from . import lab
+
+schema = dj.schema(dj.config['database.prefix'] + 'puffs_lab')
+
+
+@schema
+class PuffsCohort(dj.Manual):
+    definition = """
+    -> lab.User         
+    project_name         : varchar(64)                  # Corresponds to the path on bucket /puffs/netid/project_name/cohortX/ ...
+    cohort               : varchar(64)                  # Corresponds to the path on bucket /puffs/netid/project_name/cohortX/ ...
+    ---
+    """


### PR DESCRIPTION
This PR is to create 3 new databases for the U19 Air Puffs task. The acquisition db is for keeping track of which hdf5 files have been ingested already, lab schema contains the cohort information, and the behavior db holds the session, trial, trial phase and puff information. The daily ingestion script is not included in this PR.