### PR TITLE
allow specifying starting block for ephys sync

### DIFF
--- a/notebooks/ephys_element/reingest_sync_by_virmen_block.ipynb
+++ b/notebooks/ephys_element/reingest_sync_by_virmen_block.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook allows you to re-sync a recording session for a specific day, using a specific block as the start time of the nidaq stream.\n",
+    "This is handy if you, for example, started a virmen session during recording, but then closed it to relaunch a different one.\n",
+    "Normally in this case, the nidaq stream is interrupted and the sync fails, resulting in an empty list for iteration_index and trial_index.\n",
+    "See jk8386_jknpx3's recording on 2023-08-17 for an example.\n",
+    "Simply set block to the number corresponding with the correct virmen session that you wanted to record during, and repopulate the behavior synchronization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local configuration file found !!, no need to run the configuration (unless configuration has changed)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scripts.conf_file_finding import try_find_conf_file\n",
+    "try_find_conf_file()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import u19_pipeline.ephys_pipeline as ep\n",
+    "import u19_pipeline.acquisition as acquisition\n",
+    "from u19_pipeline import recording"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'recording_id': 224}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "key = {'subject_fullname': \"jk8386_jknpx3\", 'session_date': \"2023-08-17\"}\n",
+    "\n",
+    "rid = (recording.Recording.BehaviorSession & key).fetch(as_dict=True)[0]\n",
+    "key = {'recording_id': rid['recording_id']}\n",
+    "key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block = 2 # block numbering starts at 1. Set to whatever block you want to use as the virmen_start time.\n",
+    "ep.BehaviorSync.populate(key, make_kwargs={'block': block}) # when block is passed, it only starts the session at that specific block."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([(224, 5000.06, array([nan, nan, nan, ..., nan, nan, nan]), array([nan, nan, nan, ..., nan, nan, nan]))],\n",
+       "      dtype=[('recording_id', '<i8'), ('nidq_sampling_rate', '<f8'), ('iteration_index_nidq', 'O'), ('trial_index_nidq', 'O')])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(ep.BehaviorSync() & key).fetch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "datajoint_access",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/u19_pipeline/ephys_pipeline.py
+++ b/u19_pipeline/ephys_pipeline.py
@@ -17,11 +17,6 @@ import u19_pipeline.utils.ephys_utils as ephys_utils
 import u19_pipeline.utils.DemoReadSGLXData.readSGLX as readSGLX
 from u19_pipeline.utils.DemoReadSGLXData.readSGLX import readMeta
 
-try:
-    from ecephys_spike_sorting.modules.kilosort_helper.__main__ import get_noise_channels
-except Exception as e:
-    print(f'Error in loading "ecephys_spike_sorting" package - {str(e)}')
-
 schema = dj.schema(dj.config['custom']['database.prefix'] + 'ephys_pipeline')
 
 lfp_filter_params = 'biquad,2,0,500'
@@ -216,9 +211,9 @@ class BehaviorSync(dj.Imported):
         ephys_sampling_rate: float     # sampling rate of the headstage of a probe, imSampRate in imec meta file
         """
 
-    def make(self, key):
+    def make(self, key, **kwargs):
         # Pull the Nidaq file/record
-
+        print(key)
         try:
             session_dir = find_full_path(get_ephys_root_data_dir(),
                                         get_session_directory(key))
@@ -234,6 +229,12 @@ class BehaviorSync(dj.Imported):
 
             if 'testuser' in behavior_key['subject_fullname']:
                 return
+
+            # If a specific block is requested, add that to our behavior_key. It should be an int referring to virmen block number.
+            # This is useful for sessions in which the nidaq stream was interrupted due to restarting virmen
+            if 'block' in kwargs:
+                print('block: ', kwargs['block'])
+                behavior_key['block'] = kwargs['block']
 
             print(behavior_key)
 


### PR DESCRIPTION
ephys_pipeline.BehaviorSync make function now takes kwargs and if a block variable is passed, will synchronize to the ephys starting at that virmen block. Added a notebook that lets users specify a specific session and block number to do this for. Removed unused dependency in ephys_pipeline that produced errors for me.