### PR TITLE
Skip missing training alert for subjects scheduled for watering only

### DIFF
--- a/u19_pipeline/alert_system/water_weigh_alert/create_weighing_gui_ss.py
+++ b/u19_pipeline/alert_system/water_weigh_alert/create_weighing_gui_ss.py
@@ -684,7 +684,11 @@ def main_water_weigh_alert():
     subjects_not_weighted = subjects_not_weighted.reset_index(drop=True)
     # subjects_not_weighted = subjects_not_weighted.head()
 
-    subjects_not_trained = subject_data.loc[subject_data["training_status"] == 1, ["subject_fullname", "scheduled_rig"]]
+    subjects_not_trained = subject_data.loc[
+        (subject_data["training_status"] == 1)
+        & (subject_data["schedule_today"].str.lower() != "water"),
+        ["subject_fullname", "scheduled_rig"],
+    ]
     subjects_not_trained = subjects_not_trained.reset_index(drop=True)
     # subjects_not_trained = subjects_not_trained.head()
 

--- a/u19_pipeline/alert_system/water_weigh_alert/water_weigh_alert.py
+++ b/u19_pipeline/alert_system/water_weigh_alert/water_weigh_alert.py
@@ -684,7 +684,11 @@ def main_water_weigh_alert():
     subjects_not_weighted = subjects_not_weighted.reset_index(drop=True)
     # subjects_not_weighted = subjects_not_weighted.head()
 
-    subjects_not_trained = subject_data.loc[subject_data["training_status"] == 1, ["subject_fullname", "scheduled_rig"]]
+    subjects_not_trained = subject_data.loc[
+        (subject_data["training_status"] == 1)
+        & (subject_data["schedule_today"].str.lower() != "water"),
+        ["subject_fullname", "scheduled_rig"],
+    ]
     subjects_not_trained = subjects_not_trained.reset_index(drop=True)
     # subjects_not_trained = subjects_not_trained.head()
 


### PR DESCRIPTION
## Summary

When a subject's daily responsibility is set to `Water` (watering only), they should not appear in the missing training alert table — they are not expected to be trained that day.

## Changes

- `water_weigh_alert.py`: Added filter to exclude subjects with `schedule_today == "Water"` from `subjects_not_trained`
- `create_weighing_gui_ss.py`: Same fix applied to the GUI spreadsheet variant

## Root Cause

The `subjects_not_trained` filter only checked `training_status == 1` (scheduled but not yet started), without accounting for subjects whose schedule for the day is watering only. This caused watering-only subjects to be incorrectly flagged as missing training.